### PR TITLE
Add level support and fix dps distribution calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Other
 math/*
+.vscode/*
 
 # Build
 ffxiv_stats.egg-info/

--- a/ffxiv_stats/__init__.py
+++ b/ffxiv_stats/__init__.py
@@ -6,7 +6,7 @@ This module computes exact damage/DPS distributions or the first three moments (
 
 """
 
-__version__ = "0.2.1"
+__version__ = "0.3.0"
 
 from ffxiv_stats import moments, rate, jobs
 from ffxiv_stats.moments import Rotation

--- a/ffxiv_stats/jobs.py
+++ b/ffxiv_stats/jobs.py
@@ -127,7 +127,7 @@ class BaseStats(Rotation):
         # TODO: add GCD (probably not essential?)
         pass
 
-    def attach_rotation(self, rotation_df, t, convolve_all=False):
+    def attach_rotation(self, rotation_df, t, convolve_all=False, delta=250):
         """
         Attach a rotation data frame and compute the corresponding DPS distribution.
 
@@ -176,7 +176,7 @@ class BaseStats(Rotation):
         rotation_df['d2'] = d2
         rotation_df['is_dot'] = is_dot
 
-        super().__init__(rotation_df, t, convolve_all)
+        super().__init__(rotation_df, t, convolve_all, delta)
         pass
 
     def auto_attack_d2(self, potency, ap_adjust=0, stat_override=None):

--- a/ffxiv_stats/jobs.py
+++ b/ffxiv_stats/jobs.py
@@ -3,20 +3,21 @@ from numpy import floor as nf
 import pandas as pd
 
 from .moments import Rotation
+from modifiers import level_mod
 
 class BaseStats(Rotation):
 
     def __init__(self, attack_power, trait, main_stat, mind, intelligence, vitality, strength, dexterity,
-                 det, tenacity, crit_stat, dh_stat, dot_speed_stat, auto_speed_stat, weapon_damage, delay) -> None:
+                 det, tenacity, crit_stat, dh_stat, dot_speed_stat, auto_speed_stat, weapon_damage, delay, level=90) -> None:
         """
         Base class for converting potency to base damage dealt. Not meant to be used alone.
         Instead use a `ROLE` class, which inherits this class.
         """
         # Level dependent parameters
         # currently for lvl 90
-        self.lvl_div = 1900
-        self.lvl_sub = 400
-        self.lvl_main = 390
+        self.lvl_main = level_mod[level]["lvl_main"]
+        self.lvl_sub = level_mod[level]["lvl_sub"]
+        self.lvl_div = level_mod[level]["lvl_div"]
         self.job_attribute = 115
         # Set this to 156 if tank
         self.atk_mod = 190
@@ -222,7 +223,7 @@ class BaseStats(Rotation):
 
 class Healer(BaseStats):
     def __init__(self, mind, intelligence, vitality, strength, dexterity, det, 
-                 skill_speed, spell_speed, tenacity, crit_stat, dh_stat, weapon_damage, delay) -> None:
+                 skill_speed, spell_speed, tenacity, crit_stat, dh_stat, weapon_damage, delay, level=90) -> None:
         """
         Set healer-specific stats with this class like main stat, traits, etc.
 
@@ -242,18 +243,20 @@ class Healer(BaseStats):
         delay - weapon delay stat
         """
         super().__init__(mind, 130, mind, mind, intelligence, vitality, strength, dexterity, det,
-                         tenacity, crit_stat, dh_stat, spell_speed, skill_speed, weapon_damage, delay)
+                         tenacity, crit_stat, dh_stat, spell_speed, skill_speed, weapon_damage, delay, level=90)
 
         self.auto_trait = 100
         self.atk_mod = 195
+        self.job_attribute = 115
+
         self.dot_speed_stat = spell_speed
         self.auto_speed_stat = skill_speed
         self.add_role('Healer')
         pass
 
 # class Tank(BaseStats):
-#     def __init__(self, mind, intelligence, vitality, strength, dexterity,
-#                  det, skill_speed, spell_speed, tenacity, crit_stat, dh_stat, weapon_damage, delay) -> None:
+#     def __init__(self, mind:int, intelligence:int, vitality:int, strength:int, dexterity:int,
+#                  det:int, skill_speed:int, spell_speed:int, tenacity:int, crit_stat:int, dh_stat:int, weapon_damage:int, delay, job:str, level=90) -> None:
 #         """
 #         Set tank-specific stats with this class like main stat, traits, etc.
 #         Most importantly this adjusts the attack modifier.
@@ -274,7 +277,14 @@ class Healer(BaseStats):
 #         delay - weapon delay stat
 #         """
 #         super().__init__(strength, 100, strength, mind, intelligence, vitality, strength, dexterity, 
-#                          det, tenacity, crit_stat, dh_stat, skill_speed, skill_speed, weapon_damage, delay)   
+#                          det, tenacity, crit_stat, dh_stat, skill_speed, skill_speed, weapon_damage, delay, level=90)   
+
+#         if (job.upper() == "WAR") | (job.upper() == "DRK"):
+#             self.job_attribute = 105
+#         elif (job.upper() == "PLD") | (job.upper() == "GNB"):
+#             self.job_attribute = 100
+#         else:
+#             raise ValueError(f"Incorrect job of {job} specified. Values of 'WAR', 'PLD', 'DRK', or 'GNB' are allowed ")
 
 #         self.add_role('Tank')
 #         self.atk_mod = 156
@@ -286,7 +296,7 @@ class Healer(BaseStats):
 
 # class PhysicalRanged(BaseStats):
 #     def __init__(self, mind, intelligence, vitality, strength, dexterity, det, 
-#                  skill_speed, spell_speed, tenacity, crit_stat, dh_stat, weapon_damage, delay) -> None:
+#                  skill_speed, spell_speed, tenacity, crit_stat, dh_stat, weapon_damage, delay, level=90) -> None:
 #         """
 #         Set physical ranged-specific stats with this class like main stat, traits, etc.
 
@@ -306,7 +316,7 @@ class Healer(BaseStats):
 #         delay - weapon delay stat
 #         """
 #         super().__init__(dexterity, 120, dexterity, mind, intelligence, vitality, strength, dexterity, det, 
-#                          tenacity, crit_stat, dh_stat, skill_speed, skill_speed, weapon_damage, delay)
+#                          tenacity, crit_stat, dh_stat, skill_speed, skill_speed, weapon_damage, delay, level=90)
 
 #         self.add_role('Physical Ranged')
         
@@ -316,7 +326,7 @@ class Healer(BaseStats):
 
 # class MagicalRanged(BaseStats):
 #     def __init__(self, mind, intelligence, vitality, strength, dexterity, det, 
-#                  skill_speed, spell_speed, tenacity, crit_stat, dh_stat, weapon_damage, delay) -> None:
+#                  skill_speed, spell_speed, tenacity, crit_stat, dh_stat, weapon_damage, delay, level=90) -> None:
 #         """
 #         Set magical ranged-specific stats with this class like main stat, traits, etc.
 
@@ -336,7 +346,7 @@ class Healer(BaseStats):
 #         delay - weapon delay stat
 #         """
 #         super().__init__(intelligence, 130, intelligence, mind, intelligence, vitality, strength, dexterity, det, 
-#                          tenacity, crit_stat, dh_stat, spell_speed, skill_speed, weapon_damage, delay)
+#                          tenacity, crit_stat, dh_stat, spell_speed, skill_speed, weapon_damage, delay, level=90)
 
 #         self.add_role('Caster')
         
@@ -347,7 +357,7 @@ class Healer(BaseStats):
 
 # class Melee(BaseStats):
 #     def __init__(self, mind, intelligence, vitality, strength, dexterity,
-#                  det, skill_speed, spell_speed, tenacity, crit_stat, dh_stat, weapon_damage, delay) -> None:
+#                  det, skill_speed, spell_speed, tenacity, crit_stat, dh_stat, weapon_damage, delay, level=90) -> None:
 #         """
 #         Set melee-specific stats with this class like main stat, traits, etc.
 
@@ -367,7 +377,7 @@ class Healer(BaseStats):
 #         delay - weapon delay stat
 #         """
 #         super().__init__(strength, 100, strength, mind, intelligence, vitality, strength, dexterity, 
-#                          det, tenacity, crit_stat, dh_stat, skill_speed, skill_speed, weapon_damage, delay)
+#                          det, tenacity, crit_stat, dh_stat, skill_speed, skill_speed, weapon_damage, delay, level=90)
 
 #         self.add_role('Melee')
         

--- a/ffxiv_stats/modifiers.py
+++ b/ffxiv_stats/modifiers.py
@@ -1,0 +1,17 @@
+level_mod = {
+    70: {
+        "lvl_main": 292,
+        "lvl_sub": 364,
+        "lvl_div": 900
+    },
+    80: {
+        "lvl_main": 340,
+        "lvl_sub": 380,
+        "lvl_div": 1300
+    },
+    90: {
+        "lvl_main": 390,
+        "lvl_sub": 400,
+        "lvl_div": 1900
+    }
+}

--- a/ffxiv_stats/moments.py
+++ b/ffxiv_stats/moments.py
@@ -268,7 +268,7 @@ class ActionMoments(Support):
 
 class Rotation():
 
-    def __init__(self, rotation_df, t, convolve_all=False, delta=250) -> None:
+    def __init__(self, rotation_df, t, convolve_all=False, delta:int=250) -> None:
         """
         Get damage variability for a rotation.
 
@@ -296,7 +296,11 @@ class Rotation():
                 
         self.rotation_df = rotation_df
         self.t = t
+        # Deprecated/currently unused
         self.convolve_all = convolve_all
+        # Damage is discretized by this much.
+        # Bigger number = faster but larger discretization error
+        # Smaller number = slower but more accurate.
         self.delta = delta
 
         self.action_moments = [ActionMoments(row, t) for _, row in rotation_df.iterrows()]
@@ -354,11 +358,6 @@ class Rotation():
         # A future update might work on dynamically setting this value, or allow for different spacings,
         # which are unified at the very end. 
 
-        # Damage is discretized by this much.
-        # Bigger number = faster but larger discretization error
-        # Smaller number = slower but more accurate.
-        delta = 250
-
         # section (i), individual actions
         self.action_dps_support = [None] * self.action_means.size
         self.action_dps_distributions = [None] * self.action_means.size
@@ -400,7 +399,7 @@ class Rotation():
             
             # Coarsen support in prep for rotation distribution
             uncoarsened_supported = np.arange(action_low_high[:,0].sum(), action_low_high[:,1].sum() + 1, step=1)
-            coarsened_support = np.arange(action_low_high[:,0].sum(), action_low_high[:,1].sum() + delta, step=delta)
+            coarsened_support = np.arange(action_low_high[:,0].sum(), action_low_high[:,1].sum() + self.delta, step=self.delta)
             action_dps_distribution = np.interp(coarsened_support, uncoarsened_supported, action_dps_distribution)
 
             self.unique_actions_distribution[name] = {'support': coarsened_support, 'dps_distribution': action_dps_distribution}
@@ -426,7 +425,7 @@ class Rotation():
                                                              self.rotation_dps_distribution)
 
         # Create support and convert to DPS
-        self.rotation_dps_support = np.arange(rotation_lower_bound, rotation_upper_bound+delta, step=delta).astype(float) / self.t
+        self.rotation_dps_support = np.arange(rotation_lower_bound, rotation_upper_bound+self.delta, step=self.delta).astype(float) / self.t
         # And renormalize the DPS distribution
         self.rotation_dps_distribution /= np.trapz(self.rotation_dps_distribution, self.rotation_dps_support)
 

--- a/ffxiv_stats/moments.py
+++ b/ffxiv_stats/moments.py
@@ -268,7 +268,7 @@ class ActionMoments(Support):
 
 class Rotation():
 
-    def __init__(self, rotation_df, t, convolve_all=False) -> None:
+    def __init__(self, rotation_df, t, convolve_all=False, delta=250) -> None:
         """
         Get damage variability for a rotation.
 
@@ -287,6 +287,7 @@ class Rotation():
                      is_dot: boolean or 0/1, whether the action is a damage over time effect.
         t: float, time elapsed in seconds. Set t=1 to get damage dealt instead of DPS.
         convolve_all: bool, whether to compute all DPS distributions by convolutions (normally actions with large n can be computed with a skew normal distribution).
+        delta: int, step size for damage grid used in convolving unique action distributions together.
         """
         column_check = set(["base_action", "action_name"])
         missing_columns = column_check - set(rotation_df.columns)
@@ -296,6 +297,7 @@ class Rotation():
         self.rotation_df = rotation_df
         self.t = t
         self.convolve_all = convolve_all
+        self.delta = delta
 
         self.action_moments = [ActionMoments(row, t) for _, row in rotation_df.iterrows()]
         self.action_names = rotation_df['action_name'].tolist()
@@ -341,7 +343,6 @@ class Rotation():
         # The major consideration for coarsening is when to coarsen and by how much. 
         # Coarsening leads to a greater reduction in computational efficiency when N becomes large.
         # All action distributions are initially convolved in steps of 1 damage n_hit times.
-        # TODO: test this
         # Unique action distributions are also convolved in steps of 1 damage, and then coarsened.
 
         # The action with the smallest damage span will limit how much the support can be coarsened by.

--- a/ffxiv_stats/moments.py
+++ b/ffxiv_stats/moments.py
@@ -287,7 +287,8 @@ class Rotation():
                      is_dot: boolean or 0/1, whether the action is a damage over time effect.
         t: float, time elapsed in seconds. Set t=1 to get damage dealt instead of DPS.
         convolve_all: bool, whether to compute all DPS distributions by convolutions (normally actions with large n can be computed with a skew normal distribution).
-        delta: int, step size for damage grid used in convolving unique action distributions together.
+        delta: int, step size for damage grid used in convolving unique action distributions together. How large delta can be will depend on the the damage span
+                    of a unique action (all hits normal to all hits critical direct). Values between 100-1000 are generally sufficient.
         """
         column_check = set(["base_action", "action_name"])
         missing_columns = column_check - set(rotation_df.columns)

--- a/ffxiv_stats/rate.py
+++ b/ffxiv_stats/rate.py
@@ -1,8 +1,8 @@
 import numpy as np
-
+from modifiers import level_mod
 class Rate():
 
-    def __init__(self, crit_amt, dh_amt) -> None:
+    def __init__(self, crit_amt, dh_amt, level=90) -> None:
         """
         Get probabilities of different hit types given critical hit and direct hit rate stats.
         """
@@ -10,6 +10,11 @@ class Rate():
         self.dh_amt = dh_amt
         self.p = self.get_p()
         self.l_c = self.crit_dmg_multiplier()
+
+        self.lvl_main = level_mod[level]["lvl_main"]
+        self.lvl_sub = level_mod[level]["lvl_sub"]
+        self.lvl_div = level_mod[level]["lvl_div"]
+
         pass
 
     def crit_dmg_multiplier(self) -> float:
@@ -22,7 +27,7 @@ class Rate():
         returns:
         critical hit damage multiplier
         """
-        return np.floor(200/1900 * (self.crit_amt - 400) + 1400)
+        return np.floor(200/self.lvl_div * (self.crit_amt - self.lvl_sub) + 1400)
 
     def crit_prob(self) -> float:
         """
@@ -34,7 +39,7 @@ class Rate():
         returns:
         critical hit probability, from [0,1]
         """
-        return np.floor(200/1900 * (self.crit_amt - 400) + 50) / 1000
+        return np.floor(200/self.lvl_div * (self.crit_amt - self.lvl_sub) + 50) / 1000
 
     def direct_hit_prob(self) -> float:
         """
@@ -46,7 +51,7 @@ class Rate():
         returns:
         direct hit probability, from [0,1]
         """
-        return np.floor(550/1900 * (self.dh_amt - 400)) / 1000
+        return np.floor(550/self.lvl_div * (self.dh_amt - self.lvl_sub)) / 1000
 
     def get_p(self, ch_mod=0, dh_mod=0, keep_cd=True):
         """


### PR DESCRIPTION
Support for computing damage/damage variance at level 70, 80, and 90 is now supported. All calculations default to level 90.

There were also improvements to how damage distributions are calculated. 

## Fix to rotation damage distribution
The general steps for computing damage distributions were originally

1. For each unique action, convolve the 1-hit distribution n_hit times
2. Convert these to DPS and interpolate them to a coarser grid of 0.5 dps, rounded to the nearest whole number
3. Convolve action distributions together to get the rotation dps distribution.

Step 2 was causing errors because all damage distributions need to be on the same grid, and rounding cause this to not happen. There were also issues in working in units of DPS since that generally yielded floats. This was resolved by doing all convolutions in units of damage dealt and then converting to DPS at the very end. Damage distributions can still be interpolated to a coarser damage grid (steps of 250 vs steps of 1) to help reduce computational cost. Accuracy appears to be visually identical up to steps of 1000 damage. The coarseness of discretization can be specified by the `delta` parameter.

Only unique action damage distributions and the rotation damage distribution are interpolated to a coarser damage grid. The rotation damage distribution is also computed from the unique action damage distributions, which reduces repeated convolutions.

## Performance improvements to convolutions

The way the 1-hit damage distribution is self-convolved to yield an n-hit damage distribution was made more efficient. This was originally self-convolving the 1-hit damage distribution `n_hit - 1` times, which was quite inefficient, particularly as `n_hit` grew large. This was made more efficient by expressing n_hit in terms of its partitions and convolving the 1-hit damage distribution to the partitions. The exact strategy is outlined [here, see the second comment to the question](https://math.stackexchange.com/questions/2114575/partitions-of-n-that-generate-all-numbers-smaller-than-n). When n is large (50 - 75), this method is about an order of magnitude faster than convolving 1-by-1.

![image](https://github.com/ffxiv-acerola/ffxiv_stats/assets/114882724/6bebcf9c-2958-4050-a99d-b43e8aa3cc36)
