### PR TITLE
Add highest hit for convolving

### DIFF
--- a/ffxiv_stats/__init__.py
+++ b/ffxiv_stats/__init__.py
@@ -6,7 +6,7 @@ This module computes exact damage DPS distributions or the first three moments (
 
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 from ffxiv_stats import moments, rate, jobs, modifiers
 from ffxiv_stats.moments import Rotation


### PR DESCRIPTION
Healers could not DH if no DH is melded. This messed up the length of the support and DPS distributions when zeroes were trimmed.

Also make default discretization for rotations 50 damage (was 100)